### PR TITLE
[Add] the ability to enable trusting self signed certificates; fixes 338

### DIFF
--- a/CDP4Dal/DAL/Credentials.cs
+++ b/CDP4Dal/DAL/Credentials.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="Credentials.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2020 Starion Group S.A.
+//    Copyright (c) 2015-2024 Starion Group S.A.
 //
 //    Author: Sam Gerené, Merlin Bieze, Alex Vorobiev, Naron Phou
 //
@@ -49,10 +49,14 @@ namespace CDP4Dal.DAL
         /// <param name="uri">
         /// the <see cref="Uri"/> of the data-store
         /// </param>
+        /// <param name="fullTrust">
+        /// A value indicating whether the connection shall be fully trusted or not (in case of HttpClient connections
+        /// this includes trusing self signed SSL certificates)
+        /// </param>
         /// <param name="proxySettings">
         /// The <see cref="ProxySettings"/> used to encapsulate proxy server settings
         /// </param>
-        public Credentials(string username, string password, Uri uri, ProxySettings proxySettings = null)
+        public Credentials(string username, string password, Uri uri, bool fullTrust = false, ProxySettings proxySettings = null)
         {
             if (string.IsNullOrEmpty(username))
             {
@@ -72,6 +76,7 @@ namespace CDP4Dal.DAL
             this.UserName = username;
             this.password = password;
             this.Uri = uri;
+            this.FullTrust = fullTrust;
             this.ProxySettings = proxySettings;
         }
 
@@ -95,6 +100,12 @@ namespace CDP4Dal.DAL
         /// Gets the <see cref="Uri"/> of the data-store 
         /// </summary>
         public Uri Uri { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the connection shall be fully trusted or not (in case of HttpClient connections
+        /// this includes trusing self signed SSL certificates).
+        /// </summary>
+        public bool FullTrust { get; private set; }
 
         /// <summary>
         /// Gets the settings used to connect to a Proxy server

--- a/CDP4ServicesDal.NetCore.Tests/CdpServicesDalTestFixture.cs
+++ b/CDP4ServicesDal.NetCore.Tests/CdpServicesDalTestFixture.cs
@@ -623,7 +623,7 @@ namespace CDP4ServicesDal.Tests
             var proxySettings = new ProxySettings(new Uri("http://tinyproxy:8888"));
             
             var uri = new Uri("https://cdp4services-test.cdp4.org");
-            this.credentials = new Credentials("admin", "pass", uri, proxySettings);
+            this.credentials = new Credentials("admin", "pass", uri, false, proxySettings);
 
             var dal = new CdpServicesDal();
             var result = await dal.Open(this.credentials, new CancellationToken());


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
added the capability to enable full trust of all SSL certs, including self-signed certs

<!-- Thanks for contributing to COMET-SDK! -->