### PR TITLE
[REFACTOR] ParameterOrOverrideBase instead of Parameter for DtoValueValidator.ValidateAndCleanup

### DIFF
--- a/CDP4Common/CDP4Common.csproj
+++ b/CDP4Common/CDP4Common.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4Common Community Edition</Title>
-    <VersionPrefix>27.0.0</VersionPrefix>
+    <VersionPrefix>27.0.1</VersionPrefix>
     <Description>CDP4 Common Class Library that contains DTOs, POCOs</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael, Ahmed</Authors>

--- a/CDP4Common/Validation/DtoValueValidator.cs
+++ b/CDP4Common/Validation/DtoValueValidator.cs
@@ -382,9 +382,9 @@ namespace CDP4Common.Validation
 
         /// <summary>
         /// Validates and cleanup the <see cref="ValueArray{T}" /> contained in a <see cref="ClasslessDTO" /> for a
-        /// <see cref="ParameterOrOverrideBase" />
+        /// <see cref="ParameterOverride" />
         /// </summary>
-        /// <param name="parameterOrOverrideBase">The <see cref="ParameterOrOverrideBase" /> to be validated</param>
+        /// <param name="parameterOverride">The <see cref="ParameterOverride" /> to be validated</param>
         /// <param name="classlessDto">The <see cref="ClasslessDTO" /> that contains <see cref="ValueArray{T}" /> to validate</param>
         /// <param name="things">The collection of <see cref="Thing" /> to retrieve referenced <see cref="Thing" /></param>
         /// <param name="provider">
@@ -396,11 +396,15 @@ namespace CDP4Common.Validation
         /// If the <see cref="ParameterType" /> referenced by the <see cref="ParameterOrOverrideBase" />
         /// is not contained inside the <paramref name="things" />
         /// </exception>
-        public static ValidationResult ValidateAndCleanup(this ParameterOrOverrideBase parameterOrOverrideBase, ClasslessDTO classlessDto, IReadOnlyCollection<Thing> things, IFormatProvider provider = null)
+        public static ValidationResult ValidateAndCleanup(this ParameterOverride parameterOverride, ClasslessDTO classlessDto, IReadOnlyCollection<Thing> things, IFormatProvider provider = null)
         {
+            var parameter = things.OfType<Parameter>()
+                                    .FirstOrDefault(x => x.Iid == parameterOverride.Parameter)
+                                ?? throw new ThingNotFoundException($"The provided collection of Things does not contain a reference to the Parameter {parameterOverride.Parameter}");
+
             var parameterType = things.OfType<ParameterType>()
-                                    .FirstOrDefault(x => x.Iid == parameterOrOverrideBase.ParameterType)
-                                ?? throw new ThingNotFoundException($"The provided collection of Things does not contain a reference to the ParameterType {parameterOrOverrideBase.ParameterType}");
+                                    .FirstOrDefault(x => x.Iid == parameter.ParameterType)
+                                ?? throw new ThingNotFoundException($"The provided collection of Things does not contain a reference to the ParameterType {parameter.ParameterType}");
 
             foreach (var kvp in classlessDto)
             {
@@ -409,7 +413,7 @@ namespace CDP4Common.Validation
                     continue;
                 }
 
-                var validationResult = parameterType.ValidateAndCleanup(valueArray, kvp.Key, parameterOrOverrideBase.Scale, things, provider);
+                var validationResult = parameterType.ValidateAndCleanup(valueArray, kvp.Key, parameterOverride.Scale, things, provider);
 
                 if (validationResult.ResultKind != ValidationResultKind.Valid)
                 {

--- a/CDP4Common/Validation/DtoValueValidator.cs
+++ b/CDP4Common/Validation/DtoValueValidator.cs
@@ -453,7 +453,7 @@ namespace CDP4Common.Validation
                     continue;
                 }
 
-                var validationResult = parameterType.ValidateAndCleanup(valueArray, kvp.Key, parameterOverride.Scale, things, provider);
+                var validationResult = parameterType.ValidateAndCleanup(valueArray, kvp.Key, parameter.Scale, things, provider);
 
                 if (validationResult.ResultKind != ValidationResultKind.Valid)
                 {

--- a/CDP4Common/Validation/DtoValueValidator.cs
+++ b/CDP4Common/Validation/DtoValueValidator.cs
@@ -382,9 +382,9 @@ namespace CDP4Common.Validation
 
         /// <summary>
         /// Validates and cleanup the <see cref="ValueArray{T}" /> contained in a <see cref="ClasslessDTO" /> for a
-        /// <see cref="Parameter" />
+        /// <see cref="ParameterOrOverrideBase" />
         /// </summary>
-        /// <param name="parameter">The <see cref="Parameter" /> to be validated</param>
+        /// <param name="parameterOrOverrideBase">The <see cref="ParameterOrOverrideBase" /> to be validated</param>
         /// <param name="classlessDto">The <see cref="ClasslessDTO" /> that contains <see cref="ValueArray{T}" /> to validate</param>
         /// <param name="things">The collection of <see cref="Thing" /> to retrieve referenced <see cref="Thing" /></param>
         /// <param name="provider">
@@ -393,14 +393,14 @@ namespace CDP4Common.Validation
         /// </param>
         /// <returns>a <see cref="ValidationResult" /> that carries the <see cref="ValidationResultKind" /> and an optional message.</returns>
         /// <exception cref="ThingNotFoundException">
-        /// If the <see cref="ParameterType" /> referenced by the <see cref="Parameter" />
+        /// If the <see cref="ParameterType" /> referenced by the <see cref="ParameterOrOverrideBase" />
         /// is not contained inside the <paramref name="things" />
         /// </exception>
-        public static ValidationResult ValidateAndCleanup(this Parameter parameter, ClasslessDTO classlessDto, IReadOnlyCollection<Thing> things, IFormatProvider provider = null)
+        public static ValidationResult ValidateAndCleanup(this ParameterOrOverrideBase parameterOrOverrideBase, ClasslessDTO classlessDto, IReadOnlyCollection<Thing> things, IFormatProvider provider = null)
         {
             var parameterType = things.OfType<ParameterType>()
-                                    .FirstOrDefault(x => x.Iid == parameter.ParameterType)
-                                ?? throw new ThingNotFoundException($"The provided collection of Things does not contain a reference to the ParameterType {parameter.ParameterType}");
+                                    .FirstOrDefault(x => x.Iid == parameterOrOverrideBase.ParameterType)
+                                ?? throw new ThingNotFoundException($"The provided collection of Things does not contain a reference to the ParameterType {parameterOrOverrideBase.ParameterType}");
 
             foreach (var kvp in classlessDto)
             {
@@ -409,7 +409,7 @@ namespace CDP4Common.Validation
                     continue;
                 }
 
-                var validationResult = parameterType.ValidateAndCleanup(valueArray, kvp.Key, parameter.Scale, things, provider);
+                var validationResult = parameterType.ValidateAndCleanup(valueArray, kvp.Key, parameterOrOverrideBase.Scale, things, provider);
 
                 if (validationResult.ResultKind != ValidationResultKind.Valid)
                 {

--- a/CDP4Dal/CDP4Dal.csproj
+++ b/CDP4Dal/CDP4Dal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4Dal Community Edition</Title>
-    <VersionPrefix>27.0.0</VersionPrefix>
+    <VersionPrefix>27.0.1</VersionPrefix>
     <Description>CDP4 Data Access Layer library, a consumer of an ECSS-E-TM-10-25 Annex C API</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael, Ahmed</Authors>

--- a/CDP4DalCommon/CDP4DalCommon.csproj
+++ b/CDP4DalCommon/CDP4DalCommon.csproj
@@ -5,7 +5,7 @@
       <Company>Starion Group S.A.</Company>
       <Language>latest</Language>
       <Title>CDP4DalCommon Community Edition</Title>
-      <VersionPrefix>27.0.0</VersionPrefix>
+      <VersionPrefix>27.0.1</VersionPrefix>
       <Description>CDP4 Common Class Library that contains common types for any CDP4 server and the CDP4Dal</Description>
       <Copyright>Copyright © Starion Group S.A.</Copyright>
       <Authors>Sam, Alex, Alexander, Nathanael, Antoine, Omar, Jaime</Authors>

--- a/CDP4JsonFileDal/CDP4JsonFileDal.csproj
+++ b/CDP4JsonFileDal/CDP4JsonFileDal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4JsonFileDal Community Edition</Title>
-    <VersionPrefix>27.0.0</VersionPrefix>
+    <VersionPrefix>27.0.1</VersionPrefix>
     <Description>CDP4 Json File Dal Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>

--- a/CDP4JsonSerializer/CDP4JsonSerializer.csproj
+++ b/CDP4JsonSerializer/CDP4JsonSerializer.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4JsonSerializer Community Edition</Title>
-    <VersionPrefix>27.0.0</VersionPrefix>
+    <VersionPrefix>27.0.1</VersionPrefix>
     <Description>CDP4 JSON Serialization Library</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>

--- a/CDP4MessagePackSerializer/CDP4MessagePackSerializer.csproj
+++ b/CDP4MessagePackSerializer/CDP4MessagePackSerializer.csproj
@@ -4,7 +4,7 @@
       <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
       <Company>Starion Group S.A.</Company>
       <Title>CDP4MessagePackSerializer Community Edition</Title>
-      <VersionPrefix>27.0.0</VersionPrefix>
+      <VersionPrefix>27.0.1</VersionPrefix>
       <Description>CDP4 MessagePack Serialization Library</Description>
       <Copyright>Copyright © Starion Group S.A.</Copyright>
       <Authors>Sam, Alex, Alexander, Nathanael, Antoine, Omar</Authors>

--- a/CDP4Reporting/CDP4Reporting.csproj
+++ b/CDP4Reporting/CDP4Reporting.csproj
@@ -4,7 +4,7 @@
      <TargetFrameworks>netstandard2.0</TargetFrameworks>
      <Company>Starion Group S.A.</Company>
      <Title>CDP4Reporting Community Edition</Title>
-     <VersionPrefix>27.0.0</VersionPrefix>
+     <VersionPrefix>27.0.1</VersionPrefix>
      <Description>CDP4 Reporting</Description>
      <Copyright>Copyright © Starion Group S.A.</Copyright>
      <Authors>Sam, Alex, Alexander</Authors>

--- a/CDP4RequirementsVerification/CDP4RequirementsVerification.csproj
+++ b/CDP4RequirementsVerification/CDP4RequirementsVerification.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4RequirementsVerification Community Edition</Title>
-    <VersionPrefix>27.0.0</VersionPrefix>
+    <VersionPrefix>27.0.1</VersionPrefix>
     <Description>CDP4 Class Library that provides requirement verification</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Alex, Alexander, Yevhen, Nathanael</Authors>

--- a/CDP4Rules/CDP4Rules.csproj
+++ b/CDP4Rules/CDP4Rules.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4Rules Community Edition</Title>
-    <VersionPrefix>27.0.0</VersionPrefix>
+    <VersionPrefix>27.0.1</VersionPrefix>
     <Description>CDP4 Class Library that provides Model Analysis and Rule Checking</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Alex, Alexander, Yevhen, Nathanael</Authors>

--- a/CDP4ServicesDal/CDP4ServicesDal.csproj
+++ b/CDP4ServicesDal/CDP4ServicesDal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4ServicesDal Community Edition</Title>
-    <VersionPrefix>27.0.0</VersionPrefix>
+    <VersionPrefix>27.0.1</VersionPrefix>
     <Description>CDP4ServicesDal Dal Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>

--- a/CDP4ServicesMessaging/CDP4ServicesMessaging.csproj
+++ b/CDP4ServicesMessaging/CDP4ServicesMessaging.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4Common Community Edition</Title>
-    <VersionPrefix>27.0.0</VersionPrefix>
+    <VersionPrefix>27.0.1</VersionPrefix>
     <Description>CDP4 Services Messaging is a Class Library that contains clients and messages class that can be used for inter services communication</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Alex, Alexander, Nathanael, Antoine</Authors>

--- a/CDP4Web/CDP4Web.csproj
+++ b/CDP4Web/CDP4Web.csproj
@@ -5,7 +5,7 @@
         <LangVersion>latest</LangVersion>
         <Company>Starion Group S.A.</Company>
         <Title>CDP4Web Community Edition</Title>
-        <VersionPrefix>27.0.0</VersionPrefix>
+        <VersionPrefix>27.0.1</VersionPrefix>
         <Description>CDP4Web Dedicated Sdk for CDPServicesDal</Description>
         <Copyright>Copyright © Starion Group S.A.</Copyright>
         <Authors>Sam, Alex, Alexander, Nathanael, Antoine, Omar, Jaime</Authors>

--- a/CDP4WspDal/CDP4WspDal.csproj
+++ b/CDP4WspDal/CDP4WspDal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4WspDal Community Edition</Title>
-    <VersionPrefix>27.0.0</VersionPrefix>
+    <VersionPrefix>27.0.1</VersionPrefix>
     <Description>CDP4 WSP Dal Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
[REFACTOR] ParameterOrOverrideBase instead of Parameter for DtoValueValidator.ValidateAndCleanup