### PR TITLE
[WIP][FIX] PermissionService Owned Things directly contained in EngineeringModel and their full containment tree

### DIFF
--- a/CDP4Common/CDP4Common.csproj
+++ b/CDP4Common/CDP4Common.csproj
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [ADD] Implement ExceptionHandlerService
+      [FIX] PermissionService
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4Common/CDP4Common.csproj
+++ b/CDP4Common/CDP4Common.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4Common Community Edition</Title>
-    <VersionPrefix>27.1.0</VersionPrefix>
+    <VersionPrefix>27.2.0</VersionPrefix>
     <Description>CDP4 Common Class Library that contains DTOs, POCOs</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael, Ahmed</Authors>

--- a/CDP4Dal.NetCore.Tests/Permission/PermissionServiceTestFixture.cs
+++ b/CDP4Dal.NetCore.Tests/Permission/PermissionServiceTestFixture.cs
@@ -70,6 +70,7 @@ namespace CDP4Dal.Tests.Permission
 
         private PermissionService permissionService;
         private CommonFileStore commonFileStore;
+        private File file;
 
         [SetUp]
         public void Setup()
@@ -103,6 +104,7 @@ namespace CDP4Dal.Tests.Permission
             this.requirementsSpecification = new RequirementsSpecification(Guid.NewGuid(), this.assembler.Cache, this.uri);
             this.requirement = new Requirement(Guid.NewGuid(), this.assembler.Cache, this.uri);
             this.commonFileStore = new CommonFileStore(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            this.file = new File(Guid.NewGuid(), this.assembler.Cache, this.uri);
 
             this.sitedir.Model.Add(this.modelsetup);
             this.sitedir.Person.Add(this.person);
@@ -134,6 +136,8 @@ namespace CDP4Dal.Tests.Permission
             this.requirementsSpecification.Requirement.Add(this.requirement);
             this.iteration.RequirementsSpecification.Add(this.requirementsSpecification);
             this.model.CommonFileStore.Add(this.commonFileStore);
+            this.file.Owner = this.domain1;
+            this.commonFileStore.File.Add(this.file);
 
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
@@ -172,6 +176,7 @@ namespace CDP4Dal.Tests.Permission
 
             Assert.That(this.permissionService.CanRead(this.model), Is.False);
             Assert.That(this.permissionService.CanRead(this.iteration), Is.False);
+            Assert.That(this.permissionService.CanRead(this.file), Is.False);
         }
 
         [Test]
@@ -399,8 +404,37 @@ namespace CDP4Dal.Tests.Permission
 
             //Thing has other owner as User's participant
             this.commonFileStore.Owner = this.domain2;
-            Assert.That(this.permissionService.CanWrite(this.commonFileStore), Is.True);
+            Assert.That(this.permissionService.CanWrite(this.commonFileStore), Is.False);
             Assert.That(this.permissionService.CanRead(this.commonFileStore), Is.True);
+        }
+
+        [Test]
+        public void VerifyModifyIfOwnerForThingsThatContainedInThingsThatAreDirectlyUnderEngineeringModel()
+        {
+            this.session.Setup(x => x.ActivePersonParticipants).Returns(new List<Participant> { this.participant });
+            Assert.That(this.permissionService.CanWrite(this.model), Is.False);
+            Assert.That(this.permissionService.CanRead(this.model), Is.False);
+
+            var permission =
+                this.participantRole.ParticipantPermission.Single(x => x.ObjectClass == ClassKind.File);
+
+            permission.AccessRight = ParticipantAccessRightKind.MODIFY_IF_OWNER;
+
+            this.file.Owner = null;
+
+            //Thing has no owner
+            Assert.Throws<IncompleteModelException>(() => this.permissionService.CanWrite(this.file));
+            Assert.Throws<IncompleteModelException>(() => this.permissionService.CanRead(this.file));
+
+            //Thing has same owner as User's participant
+            this.file.Owner = this.domain1;
+            Assert.That(this.permissionService.CanWrite(this.file), Is.True);
+            Assert.That(this.permissionService.CanRead(this.file), Is.True);
+
+            //Thing has other owner as User's participant
+            this.file.Owner = this.domain2;
+            Assert.That(this.permissionService.CanWrite(this.file), Is.False);
+            Assert.That(this.permissionService.CanRead(this.file), Is.True);
         }
 
         [Test]

--- a/CDP4Dal/CDP4Dal.csproj
+++ b/CDP4Dal/CDP4Dal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4Dal Community Edition</Title>
-    <VersionPrefix>27.1.0</VersionPrefix>
+    <VersionPrefix>27.2.0</VersionPrefix>
     <Description>CDP4 Data Access Layer library, a consumer of an ECSS-E-TM-10-25 Annex C API</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael, Ahmed</Authors>

--- a/CDP4Dal/CDP4Dal.csproj
+++ b/CDP4Dal/CDP4Dal.csproj
@@ -20,8 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [BUMP] To CDP4Common 27.1.0
-      [ADD] Use ExceptionHandlerService in Session
+      [FIX] PermissionService
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4DalCommon/CDP4DalCommon.csproj
+++ b/CDP4DalCommon/CDP4DalCommon.csproj
@@ -5,7 +5,7 @@
       <Company>Starion Group S.A.</Company>
       <Language>latest</Language>
       <Title>CDP4DalCommon Community Edition</Title>
-      <VersionPrefix>27.1.0</VersionPrefix>
+      <VersionPrefix>27.2.0</VersionPrefix>
       <Description>CDP4 Common Class Library that contains common types for any CDP4 server and the CDP4Dal</Description>
       <Copyright>Copyright © Starion Group S.A.</Copyright>
       <Authors>Sam, Alex, Alexander, Nathanael, Antoine, Omar, Jaime</Authors>

--- a/CDP4DalCommon/CDP4DalCommon.csproj
+++ b/CDP4DalCommon/CDP4DalCommon.csproj
@@ -21,7 +21,7 @@
       <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
       <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
       <PackageReleaseNotes>
-        [BUMP] To CDP4Common 27.1.0
+        [BUMP] To CDP4Common 27.2.0
       </PackageReleaseNotes>
       <PackageReadmeFile>README.md</PackageReadmeFile>
       <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/CDP4JsonFileDal/CDP4JsonFileDal.csproj
+++ b/CDP4JsonFileDal/CDP4JsonFileDal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4JsonFileDal Community Edition</Title>
-    <VersionPrefix>27.1.0</VersionPrefix>
+    <VersionPrefix>27.2.0</VersionPrefix>
     <Description>CDP4 Json File Dal Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>

--- a/CDP4JsonFileDal/CDP4JsonFileDal.csproj
+++ b/CDP4JsonFileDal/CDP4JsonFileDal.csproj
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [BUMP] To CDP4Common 27.1.0
+      [BUMP] To CDP4Common 27.2.0
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4JsonSerializer/CDP4JsonSerializer.csproj
+++ b/CDP4JsonSerializer/CDP4JsonSerializer.csproj
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25 JSON</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [BUMP] To CDP4Common 27.1.0
+      [BUMP] To CDP4Common 27.2.0
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4JsonSerializer/CDP4JsonSerializer.csproj
+++ b/CDP4JsonSerializer/CDP4JsonSerializer.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4JsonSerializer Community Edition</Title>
-    <VersionPrefix>27.1.0</VersionPrefix>
+    <VersionPrefix>27.2.0</VersionPrefix>
     <Description>CDP4 JSON Serialization Library</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>

--- a/CDP4MessagePackSerializer/CDP4MessagePackSerializer.csproj
+++ b/CDP4MessagePackSerializer/CDP4MessagePackSerializer.csproj
@@ -4,7 +4,7 @@
       <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
       <Company>Starion Group S.A.</Company>
       <Title>CDP4MessagePackSerializer Community Edition</Title>
-      <VersionPrefix>27.1.0</VersionPrefix>
+      <VersionPrefix>27.2.0</VersionPrefix>
       <Description>CDP4 MessagePack Serialization Library</Description>
       <Copyright>Copyright © Starion Group S.A.</Copyright>
       <Authors>Sam, Alex, Alexander, Nathanael, Antoine, Omar</Authors>

--- a/CDP4MessagePackSerializer/CDP4MessagePackSerializer.csproj
+++ b/CDP4MessagePackSerializer/CDP4MessagePackSerializer.csproj
@@ -20,7 +20,7 @@
       <PackageTags>CDP COMET ECSS-E-TM-10-25 MessagePack</PackageTags>
       <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
       <PackageReleaseNotes>
-        [BUMP] To CDP4Common 27.1.0
+        [BUMP] To CDP4Common 27.2.0
       </PackageReleaseNotes>
       <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4Reporting/CDP4Reporting.csproj
+++ b/CDP4Reporting/CDP4Reporting.csproj
@@ -4,7 +4,7 @@
      <TargetFrameworks>netstandard2.0</TargetFrameworks>
      <Company>Starion Group S.A.</Company>
      <Title>CDP4Reporting Community Edition</Title>
-     <VersionPrefix>27.1.0</VersionPrefix>
+     <VersionPrefix>27.2.0</VersionPrefix>
      <Description>CDP4 Reporting</Description>
      <Copyright>Copyright © Starion Group S.A.</Copyright>
      <Authors>Sam, Alex, Alexander</Authors>

--- a/CDP4Reporting/CDP4Reporting.csproj
+++ b/CDP4Reporting/CDP4Reporting.csproj
@@ -20,7 +20,7 @@
      <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
      <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
      <PackageReleaseNotes>
-       [BUMP] To CDP4Common 27.1.0
+       [BUMP] To CDP4Common 27.2.0
      </PackageReleaseNotes>
      <LangVersion>latest</LangVersion>
      <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/CDP4RequirementsVerification/CDP4RequirementsVerification.csproj
+++ b/CDP4RequirementsVerification/CDP4RequirementsVerification.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4RequirementsVerification Community Edition</Title>
-    <VersionPrefix>27.1.0</VersionPrefix>
+    <VersionPrefix>27.2.0</VersionPrefix>
     <Description>CDP4 Class Library that provides requirement verification</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Alex, Alexander, Yevhen, Nathanael</Authors>

--- a/CDP4RequirementsVerification/CDP4RequirementsVerification.csproj
+++ b/CDP4RequirementsVerification/CDP4RequirementsVerification.csproj
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [BUMP] To CDP4Common 27.1.0
+      [BUMP] To CDP4Common 27.2.0
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4Rules/CDP4Rules.csproj
+++ b/CDP4Rules/CDP4Rules.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4Rules Community Edition</Title>
-    <VersionPrefix>27.1.0</VersionPrefix>
+    <VersionPrefix>27.2.0</VersionPrefix>
     <Description>CDP4 Class Library that provides Model Analysis and Rule Checking</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Alex, Alexander, Yevhen, Nathanael</Authors>

--- a/CDP4Rules/CDP4Rules.csproj
+++ b/CDP4Rules/CDP4Rules.csproj
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [BUMP] To CDP4Common 27.1.0
+      [BUMP] To CDP4Common 27.2.0
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4ServicesDal/CDP4ServicesDal.csproj
+++ b/CDP4ServicesDal/CDP4ServicesDal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4ServicesDal Community Edition</Title>
-    <VersionPrefix>27.1.0</VersionPrefix>
+    <VersionPrefix>27.2.0</VersionPrefix>
     <Description>CDP4ServicesDal Dal Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>

--- a/CDP4ServicesDal/CDP4ServicesDal.csproj
+++ b/CDP4ServicesDal/CDP4ServicesDal.csproj
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [BUMP] To CDP4Common 27.1.0
+      [BUMP] To CDP4Common 27.2.0
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/CDP4ServicesMessaging/CDP4ServicesMessaging.csproj
+++ b/CDP4ServicesMessaging/CDP4ServicesMessaging.csproj
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [BUMP] To CDP4Common 27.1.0
+      [BUMP] To CDP4Common 27.2.0
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <LangVersion>latest</LangVersion>

--- a/CDP4ServicesMessaging/CDP4ServicesMessaging.csproj
+++ b/CDP4ServicesMessaging/CDP4ServicesMessaging.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4Common Community Edition</Title>
-    <VersionPrefix>27.1.0</VersionPrefix>
+    <VersionPrefix>27.2.0</VersionPrefix>
     <Description>CDP4 Services Messaging is a Class Library that contains clients and messages class that can be used for inter services communication</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Alex, Alexander, Nathanael, Antoine</Authors>

--- a/CDP4Web/CDP4Web.csproj
+++ b/CDP4Web/CDP4Web.csproj
@@ -21,7 +21,7 @@
         <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
         <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
         <PackageReleaseNotes>
-          [BUMP] To CDP4Common 27.1.0
+          [BUMP] To CDP4Common 27.2.0
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>

--- a/CDP4Web/CDP4Web.csproj
+++ b/CDP4Web/CDP4Web.csproj
@@ -5,7 +5,7 @@
         <LangVersion>latest</LangVersion>
         <Company>Starion Group S.A.</Company>
         <Title>CDP4Web Community Edition</Title>
-        <VersionPrefix>27.1.0</VersionPrefix>
+        <VersionPrefix>27.2.0</VersionPrefix>
         <Description>CDP4Web Dedicated Sdk for CDPServicesDal</Description>
         <Copyright>Copyright © Starion Group S.A.</Copyright>
         <Authors>Sam, Alex, Alexander, Nathanael, Antoine, Omar, Jaime</Authors>

--- a/CDP4WspDal/CDP4WspDal.csproj
+++ b/CDP4WspDal/CDP4WspDal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <Company>Starion Group S.A.</Company>
     <Title>CDP4WspDal Community Edition</Title>
-    <VersionPrefix>27.1.0</VersionPrefix>
+    <VersionPrefix>27.2.0</VersionPrefix>
     <Description>CDP4 WSP Dal Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <Authors>Sam, Merlin, Alex, Naron, Alexander, Yevhen, Nathanael</Authors>

--- a/CDP4WspDal/CDP4WspDal.csproj
+++ b/CDP4WspDal/CDP4WspDal.csproj
@@ -20,7 +20,7 @@
     <PackageTags>CDP COMET ECSS-E-TM-10-25</PackageTags>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <PackageReleaseNotes>
-      [BUMP] To CDP4Common 27.1.0
+      [BUMP] To CDP4Common 27.2.0
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-SDK-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-SDK-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
[FIX] PermissionService Owned Things directly contained in EngineeringModel and their full containment tree